### PR TITLE
✨ Mark issues as read

### DIFF
--- a/communication.md
+++ b/communication.md
@@ -144,6 +144,9 @@ use the following labels:
    share with the team.
 *  `Heartbeat` when you want to give an update on how things are
    going
+   
+Mark an issue as read through the 👀 reaction to let people know they
+are not talking into empty space.
 
 Sometimes, we might want to share knowledge that is not documentation
 but is supposed to have a longer lifespan than a GitHub issue. This


### PR DESCRIPTION
I feel that issues that don't require direct input feel a bit sad, because there is no way to know if anybody even read. Also, we could close issues sooner once we see that everybody has read it.